### PR TITLE
Fix rendering of text in textarea if 'htmlToolbar' is undefined

### DIFF
--- a/jdyna-web/jdyna-web-webapp/jdyna-webmvc/jdyna-webmvc-api/src/main/resources/META-INF/tags/display.tag
+++ b/jdyna-web/jdyna-web-webapp/jdyna-webmvc/jdyna-webmvc-api/src/main/resources/META-INF/tags/display.tag
@@ -391,7 +391,7 @@
 				<c:set var="style" value="style=\"${minheight}${minwidth}\"" />
 			</c:if>
 			<c:set var="displayObject" value="${value.value.real}" />
-			<div ${style}>${tipologia.rendering.htmlToolbar eq 'nessuna'?dyna:nl2br(displayObject):displayObject}</div>
+			<div ${style}>${empty tipologia.rendering.htmlToolbar or tipologia.rendering.htmlToolbar eq 'nessuna'?dyna:nl2br(displayObject):displayObject}</div>
 			<c:if test="${editMode}">
   				<c:choose>
   				<c:when test="${value.visibility==1}">


### PR DESCRIPTION
## Rational
(Fixes issue mentioned in https://github.com/4Science/DSpace/pull/85)
Render content of multiline text area properly if `htmlToolbar` is undefinded.

## Bug?
The issue mentioned above might not be flaw in JDynA but intentionally. So instead of this PR https://github.com/4Science/DSpace/pull/85 might be the proper solution.